### PR TITLE
'spinupResult' output object name typo fix

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -323,7 +323,7 @@ spinup <- function(sim) {
 
 ##TODO Comparison of spinup results with other CBM runs needs to be completed.
 ##Scott has it on his list
-  sim$spinupResults <- cbm_vars$pools
+  sim$spinupResult <- cbm_vars$pools
   sim$cbm_vars <- cbm_vars
   return(invisible(sim))
 }


### PR DESCRIPTION
'spinupResult' output object name typo fix: assigned as 'spinupResults' (with an s)

See output definition: https://github.com/PredictiveEcology/CBM_core/blob/development/CBM_core.R#L93