### PR TITLE
fix to assign mean annual temperature to cbm_vars$parameters when no disturbances year 1

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -718,6 +718,11 @@ annual <- function(sim) {
       cbm_vars$parameters$row_idx <- cbm_vars$parameters$row_idx
     }
 
+    if (is.na(cbm_vars$parameters$mean_annual_temperature[1])) {
+      spatialIDTemperature <- sim$spinupSQL[pixelGroupForAnnual, on = .(id = spatial_unit_id)]
+      cbm_vars$parameters <- as.data.table(cbm_vars$parameters)[, mean_annual_temperature := spatialIDTemperature$mean_annual_temperature]
+    }
+
     #add age: ages needs to be update with the ages in cbm_vars$state$age
     cbm_vars$parameters$age <- cbm_vars$state$age
     #make annual_increments


### PR DESCRIPTION
This fix also solves the issue with cbm_vars$flux being assigned NaN values after the python functions with runs where the first year has no disturbances. 