### PR TITLE
libcbmr added to module dependencies

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -13,7 +13,8 @@ defineModule(sim, list(
     "data.table", "ggplot2", "quickPlot", "magrittr", "terra", "RSQLite",
     "PredictiveEcology/CBMutils@development", "PredictiveEcology/reproducible",
     "PredictiveEcology/SpaDES.core@development",
-    "PredictiveEcology/LandR@development (>= 1.1.1)"
+    "PredictiveEcology/LandR@development (>= 1.1.1)",
+    "PredictiveEcology/libcbmr"
   ),
   parameters = rbind(
     defineParameter(


### PR DESCRIPTION
`libcbmr` is being installed by the `spadesCBM` in `setupProject` when it should be a required package for this module. I'll send an update to `spadesCBM` removing it from the package list after this!