### PR TITLE
follow-up fix to cbm_vars tables to allow first sim to run

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -799,7 +799,6 @@ annual <- function(sim) {
   }
 
 cbm_vars$pools <- cbm_vars$pools[(cbm_vars$pools$row_idx %in% pixelCount$pixelGroup),]
-
   ###################### Working on cbm_vars$flux
   ######################################################
   # we are ASSUMING that these are sorted by pixelGroup like all other tables in
@@ -809,10 +808,11 @@ cbm_vars$pools <- cbm_vars$pools[(cbm_vars$pools$row_idx %in% pixelCount$pixelGr
   # "pandas.index")=RangeIndex(start=0, stop=41, step=1)
 cbm_vars$flux <- as.data.table(cbm_vars$flux)
   if (dim(distPixels)[1] > 0) {
-      cbm_vars$flux <- rbind(cbm_vars$flux, cbm_vars$flux[match(newGCpixelGroup$oldGroup, cbm_vars$flux$row_idx),])
       if (is.null(cbm_vars$flux$row_idx)) {
+        cbm_vars$flux <- rbind(cbm_vars$flux, cbm_vars$flux[newGCpixelGroup$oldGroup,])
         cbm_vars$flux$row_idx <- 1:nrow(cbm_vars$flux)
       } else {
+        cbm_vars$flux <- rbind(cbm_vars$flux, cbm_vars$flux[match(newGCpixelGroup$oldGroup, cbm_vars$flux$row_idx),])
         cbm_vars$flux[(.N-((length(part2$pixelGroup))-1)): .N, "row_idx" := part2[, pixelGroup]]
       }
       cbm_vars$flux <- cbm_vars$flux[(cbm_vars$flux$row_idx %in% pixelCount$pixelGroup),]
@@ -829,10 +829,11 @@ cbm_vars$flux <- as.data.table(cbm_vars$flux)
   # "pandas.index")=RangeIndex(start=0, stop=41, step=1)
 cbm_vars$state <- as.data.table(cbm_vars$state)
   if (dim(distPixels)[1] > 0) {
-    cbm_vars$state <- rbind(cbm_vars$state, cbm_vars$state[match(newGCpixelGroup$oldGroup, cbm_vars$state$row_idx),])
     if (is.null(cbm_vars$state$row_idx)) {
+      cbm_vars$state <- rbind(cbm_vars$state, cbm_vars$state[newGCpixelGroup$oldGroup,])
       cbm_vars$state$row_idx <- 1:nrow(cbm_vars$state)
     } else {
+      cbm_vars$state <- rbind(cbm_vars$state, cbm_vars$state[match(newGCpixelGroup$oldGroup, cbm_vars$state$row_idx),])
       cbm_vars$state[(.N-((length(part2$pixelGroup))-1)): .N, "row_idx" := part2[, pixelGroup]]
     }
     cbm_vars$state <- cbm_vars$state[(cbm_vars$state$row_idx %in% pixelCount$pixelGroup),]


### PR DESCRIPTION
Previous PR accidentally made it impossible for the first simulation year to successfully run due to the way the row_idx column is created in the first simyear