### PR TITLE
module dependency update

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -10,9 +10,8 @@ defineModule(sim, list(
   citation = list("citation.bib"),
   documentation = list("README.txt", "CBM_core.Rmd"),
   reqdPkgs = list(
-    "data.table", "ggplot2", "quickPlot", "magrittr", "terra", "RSQLite", "cowplot",
-    "PredictiveEcology/CBMutils@development", "PredictiveEcology/reproducible",
-    "PredictiveEcology/SpaDES.core@development",
+    "data.table", "terra",
+    "PredictiveEcology/CBMutils@development",
     "PredictiveEcology/LandR@development (>= 1.1.1)",
     "PredictiveEcology/libcbmr"
   ),
@@ -544,7 +543,7 @@ annual <- function(sim) {
   # create the meta data gets updated here.
 
   # only the column pixelIndex is different between distPixelCpools and pixelGroupC
-  metaDT <- unique(updateSpatialDT[, -("pixelIndex")]) # %>% .[order(pixelGroup), ]
+  metaDT <- unique(updateSpatialDT[, -("pixelIndex")]) # |> .[order(pixelGroup), ]
   setkey(metaDT, pixelGroup)
 
   # 8. link the meta data (metaDT) with the appropriate carbon pools


### PR DESCRIPTION
Did a clean up of the module required package list. The GHA should pass successfully showing that there's not any packages missing.

Removed: 
- magrittr: not used in module. There's a commented out use of a magrittr pipe (`%>%`) so I replaced it with the R pipe (`|>`) just in case.
- RSQLite: not used by this module (used by others e.g. CBM_defaults: it is listed there).
- SpaDES.core: doesn't need to be listed as it is the package running the module (will always be available).
- ggplot2, quickplot, and cowplot removed: these are dependencies of CBMutils and not called directly in the module.