### PR TITLE
'emissionProductCols' parameter fix

### DIFF
--- a/tests/testthat/devel-runTests.R
+++ b/tests/testthat/devel-runTests.R
@@ -41,3 +41,15 @@
   testthat::test_dir("tests/testthat", reporter = testthat::SummaryReporter)
 
 
+## RUN TEST SUBSETS ----
+
+  # Run module tests
+  testthat::test_dir("tests/testthat", filter = "^module")
+
+  # Run multi module integration tests
+  testthat::test_dir("tests/testthat", filter = "^multiModule")
+
+  # Run SK-small tests
+  testthat::test_dir("tests/testthat", filter = "SK-small")
+
+

--- a/tests/testthat/test-module_SK-small_1998-2000.R
+++ b/tests/testthat/test-module_SK-small_1998-2000.R
@@ -22,10 +22,10 @@ test_that("Module: SK-small 1998-2000", {
       times   = times,
       paths   = list(
         projectPath = projectPath,
-        modulePath  = spadesTestPaths$temp$modules,
+        modulePath  = dirname(spadesTestPaths$RProj),
         packagePath = spadesTestPaths$temp$packages,
         inputPath   = spadesTestPaths$temp$inputs,
-        cachePath   = spadesTestPaths$temp$cache,
+        cachePath   = file.path(projectPath, "cache"),
         outputPath  = file.path(projectPath, "outputs")
       ),
 
@@ -127,7 +127,8 @@ test_that("Module: SK-small 1998-2000", {
   expect_true(!is.null(simTest$emissionsProducts))
   expect_equal(
     data.table::as.data.table(simTest$emissionsProducts),
-    data.table::fread(file.path(spadesTestPaths$testdata, "SK-small/valid", "emissionsProducts.csv"))
+    data.table::fread(file.path(spadesTestPaths$testdata, "SK-small/valid", "emissionsProducts.csv"))[
+      , colnames(simTest$emissionsProducts), with = FALSE]
   )
 
   expect_true(!is.null(simTest$gcid_is_sw_hw))


### PR DESCRIPTION
@cboisvenue a quick change to get the 'emissionProductCols' parameter working again.

It seems that no matter what the user provides, the parameter is overwritten, because the CO2, CH4, CO, and Emissions columns are always needed for later processes like plotting. The parameter is also never used -- I was able to figure out where it was meant to be used since the same set of columns named is used later. Let me know if I got that wrong!

This update allows the user to choose but will always include those 4 columns in the result with a warning if their choice for the parameter doesn't include them.