### PR TITLE
spatialDT now uses the 'area' column to calculate emissions totals

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -695,6 +695,9 @@ annual <- function(sim) {
   emissionsProducts <- merge(sim$cbm_vars$pools[, .(row_idx, Products)], emissions, by = "row_idx")
 
   # Multiply by group areas
+  if (!"area" %in% names(sim$spatialDT)) stop(
+    "spatialDT requires the \"area\" column to calculate emissions and product totals.")
+
   groupAreas <- unique(merge(
     sim$pixelKeep[, .(pixelIndex, row_idx = pixelGroup)],
     sim$spatialDT[, .(pixelIndex, area)],

--- a/CBM_core.R
+++ b/CBM_core.R
@@ -10,7 +10,7 @@ defineModule(sim, list(
   citation = list("citation.bib"),
   documentation = list("README.txt", "CBM_core.Rmd"),
   reqdPkgs = list(
-    "data.table", "terra", "reticulate",
+    "data.table", "reticulate",
     "PredictiveEcology/CBMutils@development",
     "PredictiveEcology/LandR@development (>= 1.1.1)",
     "PredictiveEcology/libcbmr"

--- a/tests/testthat/test-module_SK-small_1998-2000.R
+++ b/tests/testthat/test-module_SK-small_1998-2000.R
@@ -36,12 +36,11 @@ test_that("Module: SK-small 1998-2000", {
         saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))
       )),
 
-      masterRaster      = terra::rast(res = 30),
-      spatialDT         = file.path(spadesTestPaths$testdata, "SK-small/input", "spatialDT.csv")         |> data.table::fread(),
+      spatialDT         = data.table::fread(file.path(spadesTestPaths$testdata, "SK-small/input", "spatialDT.csv"))[, area := 900],
       disturbanceEvents = file.path(spadesTestPaths$testdata, "SK-small/input", "disturbanceEvents.csv") |> data.table::fread(),
+      disturbanceMeta   = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceMeta.csv")   |> data.table::fread(),
       gcMeta            = file.path(spadesTestPaths$testdata, "SK/input", "gcMeta.csv")            |> data.table::fread(),
       growth_increments = file.path(spadesTestPaths$testdata, "SK/input", "growth_increments.csv") |> data.table::fread(),
-      disturbanceMeta   = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceMeta.csv")   |> data.table::fread(),
       pooldef           = file.path(spadesTestPaths$testdata, "SK/input", "pooldef.txt")           |> readLines(),
       spinupSQL         = file.path(spadesTestPaths$testdata, "SK/input", "spinupSQL.csv")         |> data.table::fread()
     )

--- a/tests/testthat/test-module_SK_1985-2011.R
+++ b/tests/testthat/test-module_SK_1985-2011.R
@@ -36,12 +36,11 @@ test_that("Module: SK 1985-2011", {
         saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))
       )),
 
-      masterRaster      = terra::rast(res = 30),
-      spatialDT         = data.table::fread(file.path(spadesTestPaths$testdata, "SK/input", "spatialDT.csv"))[, ageSpinup := sapply(ages, min, 3)],
+      spatialDT         = data.table::fread(file.path(spadesTestPaths$testdata, "SK/input", "spatialDT.csv"))[, area := 900][, ageSpinup := sapply(ages, min, 3)],
       disturbanceEvents = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceEvents.csv") |> data.table::fread(),
+      disturbanceMeta   = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceMeta.csv")   |> data.table::fread(),
       gcMeta            = file.path(spadesTestPaths$testdata, "SK/input", "gcMeta.csv")            |> data.table::fread(),
       growth_increments = file.path(spadesTestPaths$testdata, "SK/input", "growth_increments.csv") |> data.table::fread(),
-      disturbanceMeta   = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceMeta.csv")   |> data.table::fread(),
       pooldef           = file.path(spadesTestPaths$testdata, "SK/input", "pooldef.txt")           |> readLines(),
       spinupSQL         = file.path(spadesTestPaths$testdata, "SK/input", "spinupSQL.csv")         |> data.table::fread()
     )


### PR DESCRIPTION
Follows https://github.com/PredictiveEcology/CBM_dataPrep_SK/pull/53

The pixel areas within each pixel group are summed together to get a total "group area" which is then multiplied by the emissions. This allows for the pixel areas to differ in size if need be. This could potentially be relevant if we wanted to run the module with a non-projected (lat-long) projection or if we want to run the module by merging input tables from multiple study areas. Maybe unlikely but the option is there!

the `masterRaster` is no longer required for any part of the module's essential events, but it can be used in plotting if it is available in the `simList`. For this reason it hasn't been removed from the module input list entirely.