### PR TITLE
annual event: growth incremenets now assigned directly from input sim$growth_increments

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -125,9 +125,6 @@ defineModule(sim, list(
   ),
   outputObjects = bindrows(
     createsOutput(
-      objectName = "spinupInput", objectClass = "data.table",
-      desc = "Spinup inputs"),
-    createsOutput(
       objectName = "spinupResult", objectClass = "data.frame",
       desc = "Spinup results"),
     createsOutput(
@@ -332,8 +329,7 @@ spinup <- function(sim) {
     gcIndex    = "gcids"
   ) |> Cache()
 
-  # Save spinup input and output
-  sim$spinupInput  <- spinupOut["increments"]
+  # Save spinup output
   sim$spinupResult <- spinupOut$output$pools
 
   # Save cohort group key
@@ -345,7 +341,7 @@ spinup <- function(sim) {
   # Prepare spinup output data for annual event
   ## data.table with row_idx to match cohortGroupID
   sim$cbm_vars <- lapply(spinupOut$output, function(tbl){
-    tbl <- data.table::data.table(row_idx = unique(spinupOut[["increments"]]$row_idx), tbl)
+    tbl <- data.table::data.table(row_idx = sort(unique(spinupOut$key$cohortGroupID)), tbl)
     data.table::setkey(tbl, row_idx)
     tbl
   })
@@ -542,13 +538,13 @@ annual <- function(sim) {
     by = "row_idx", all.x = TRUE)
 
   # Set growth increments: join via spinup cohort group IDs and age
-  annualIncr <- cbm_vars$parameters[, .(row_idx, age)]
-  growthIncr <- sim$spinupInput$increments
-  data.table::setkeyv(growthIncr, c("row_idx", "age"))
+  growthIncr <- sim$growth_increments
+  data.table::setkeyv(growthIncr, c("gcids", "age"))
 
   ## Extend increments to maximum age found in parameters
   ## This handles cases where the cohort ages exceed what is available in the increments
-  maxIncr <- growthIncr[growthIncr[, .I[which.max(age)], by = c("gcids", "row_idx")]$V1,]
+  maxIncr <- subset(growthIncr[growthIncr[, .I[which.max(age)], by = "gcids"]$V1,],
+                    gcids %in% sim$cohortGroups$gcids)
   if (any(maxIncr$age < max(cbm_vars$parameters$age))){
 
     warning("Cohort ages exceed growth increment ages. ",
@@ -560,23 +556,16 @@ annual <- function(sim) {
           cbind(age = (maxIncr[i,]$age + 1):(max(cbm_vars$parameters$age) + 250),
                 maxIncr[i,][, -("age")])
         }), use.names = TRUE))
-    data.table::setkeyv(growthIncr, c("row_idx", "age"))
+    data.table::setkeyv(growthIncr, c("gcids", "age"))
 
-    sim$spinupInput$increments <- growthIncr
+    sim$growth_increments <- growthIncr
   }
 
   annualIncr <- merge(
-    annualIncr,
-    unique(sim$cohortGroupKeep[, .(cohortGroupID, spinup)]),
-    by.x = "row_idx", by.y = "cohortGroupID",
-    all.x = TRUE)
-  annualIncr <- merge(
-    annualIncr, growthIncr,
-    by.x = c("spinup", "age"), by.y = c("row_idx", "age"),
-    all.x = TRUE)
-  annualIncr[annualIncr$age == 0, merch_inc   := 0]
-  annualIncr[annualIncr$age == 0, other_inc   := 0]
-  annualIncr[annualIncr$age == 0, foliage_inc := 0]
+    cbm_vars$parameters[, .(row_idx, age)],
+    sim$cohortGroups[, .(row_idx = cohortGroupID, gcids)],
+    by = "row_idx")
+  annualIncr <- merge(annualIncr, growthIncr, by = c("gcids", "age"), all.x = TRUE)
 
   cbm_vars$parameters <- merge(
     cbm_vars$parameters[, .SD, .SDcols = !c("merch_inc", "foliage_inc", "other_inc")],

--- a/tests/testthat/test-module_SK-small_1998-2000.R
+++ b/tests/testthat/test-module_SK-small_1998-2000.R
@@ -62,9 +62,8 @@ test_that("Module: SK-small 1998-2000", {
 
   ## Check outputs ----
 
-  # spinupInpit and spinupResult
+  # spinupResult
   ## There should always be the same number of spinup cohort groups.
-  expect_true(!is.null(simTest$spinupInput))
   expect_true(!is.null(simTest$spinupResult))
   expect_equal(
     data.table::as.data.table(simTest$spinupResult),

--- a/tests/testthat/test-module_SK_1985-2011.R
+++ b/tests/testthat/test-module_SK_1985-2011.R
@@ -62,9 +62,8 @@ test_that("Module: SK 1985-2011", {
 
   ## Check outputs ----
 
-  # spinupInpit and spinupResult
+  # spinupResult
   ## There should always be the same number of spinup cohort groups.
-  expect_true(!is.null(simTest$spinupInput))
   expect_true(!is.null(simTest$spinupResult))
   expect_equal(
     data.table::as.data.table(simTest$spinupResult),


### PR DESCRIPTION
A suggested simplification as first discussed in our meeting yesterday. I've noticed that the `sim$growth_increments` object is nearly identical to the `sim$spinupInput$increments` table except for two small differences:

1. `sim$growth_increments` has the original `gcids` column; `sim$spinupInput` drops the `gcids` column and instead has a `row_idx` column that matches with the cohort group IDs at the time of the spinup.
2. `sim$spinupInput$increments` does not have any rows for when age == 0

You can see where we create this in the cbmExnSpinup function: it's an object we have been making rather than an object that is returned by Python: [see here](https://github.com/PredictiveEcology/CBM_core/blob/f19b4fe7581ec895f120dd014633d3558b12a59f/R/spinup.R#L43) 

**Current behaviour**: In the annual event, cohort groups are assigned increments for `libcbmr::cbm_exn_step` from the `sim$spinupInput$increments` table via the current cohort `age` and the group's original (before disturbances) `spinup` group ID from `cohortGroupKeep`.

**Updated behaviour**: In the annual event, cohort groups are assigned increments for `libcbmr::cbm_exn_step` from the `sim$growth_increments` table via the current cohort `age` and the group's `gcid`.

The tests show that the results are exactly the same; the increments that are assigned are identical. It's just a more direct join. @cboisvenue is there some reason I'm not seeing as to why this was done in the first place and/or why we shouldn't get the increments directly from `sim$growth_increments` each year? How about when age == 0? In our SK example, this would mean that `merch_inc`, `foliage_inc`, and `other_inc` would be set to 0 when age == 0. Is that right?

Also up for discussion: I took this a step further and removed the `spinupInput` object from the module outputs entirely. As it is now, it's a list of only one item, the input "increments" table (was there maybe more assigned to this list at some point?). It is only ever used in the annual event instead of the `sim$growth_increments` object. 