### PR TITLE
regeneration delay can be set by parameter or by cohortDT column

### DIFF
--- a/R/spinup.R
+++ b/R/spinup.R
@@ -88,7 +88,7 @@ cbmExnSpinup <- function(cohortDT, spinupSQL, growthIncr, gcIndex = "gcIndex"){
 #' Prepare cohort, stand, and growth curve data into a table ready for spinup.
 cbmExnSpinupCohorts <- function(
     cohortDT, standDT, gcMetaDT,
-    gcIndex         = "gcIndex",
+    gcIndex       = "gcIndex",
     default_area  = 1,
     default_delay = 0L,
     default_historical_disturbance_type = 1L,
@@ -152,6 +152,7 @@ cbmExnSpinupCohorts <- function(
     standDT$area <- default_area
   }
 
+  if ("delaySpinup" %in% names(cohortDT)) data.table::setnames(cohortDT, "delaySpinup", "delay")
   if (!"delay" %in% names(cohortDT)){
     cohortDT$delay <- default_delay
   }else{

--- a/tests/testthat/test-1-module_3-regenDelay.R
+++ b/tests/testthat/test-1-module_3-regenDelay.R
@@ -1,0 +1,128 @@
+
+if (!testthat::is_testing()) source(testthat::test_path("setup.R"))
+
+test_that("Module: with regeneration delay", {
+
+  ## Test: regeneration delay set by parameter ----
+
+  # Set times
+  times <- list(start = 2000, end = 2002)
+
+  # Set project path
+  projectPath <- file.path(spadesTestPaths$temp$projects, "module_regenDelayParam")
+  dir.create(projectPath)
+  withr::local_dir(projectPath)
+
+  # Set up project
+  simInitInput <- SpaDEStestMuffleOutput(
+
+    SpaDES.project::setupProject(
+
+      modules = "CBM_core",
+      times   = times,
+      paths   = list(
+        projectPath = projectPath,
+        modulePath  = spadesTestPaths$modulePath,
+        packagePath = spadesTestPaths$packagePath,
+        inputPath   = spadesTestPaths$inputPath,
+        cachePath   = spadesTestPaths$cachePath,
+        outputPath  = file.path(projectPath, "outputs")
+      ),
+
+      outputs = as.data.frame(expand.grid(
+        objectName = c("cbmPools", "NPP"),
+        saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))
+      )),
+
+      params = list(CBM_core = list(
+        default_delay_regen = 2
+      )),
+
+      standDT = data.table::data.table(
+        pixelIndex      = c(1, 2),
+        spatial_unit_id = 28,
+        area            = 900
+      ),
+      cohortDT = data.table::data.table(
+        cohortID   = c(1, 2),
+        pixelIndex = c(1, 2),
+        gcids      = 1,
+        ages       = 10
+      ),
+      disturbanceEvents = data.table::data.table(
+        pixelIndex = 2,
+        year       = 2000,
+        eventID    = 1
+      ),
+      disturbanceMeta = data.table::data.table(
+        eventID = 1,
+        disturbance_type_id = 1
+      ),
+      gcMeta = data.table::data.table(
+        gcids      = 1,
+        species_id = 1,
+        sw_hw      = "sw"
+      ),
+      growth_increments = data.table::data.table(
+        gcids       = 1,
+        age         = 0:100,
+        merch_inc   = c(0, seq(0.01, 1, length.out = 100)),
+        foliage_inc = c(0, seq(0.01, 1, length.out = 100)),
+        other_inc   = c(0, seq(0.01, 1, length.out = 100))
+      ),
+      pooldef   = file.path(spadesTestPaths$testdata, "SK/input", "pooldef.txt")   |> readLines(),
+      spinupSQL = file.path(spadesTestPaths$testdata, "SK/input", "spinupSQL.csv") |> data.table::fread()
+    )
+  )
+
+  # Run simInit
+  simTestInit <- SpaDEStestMuffleOutput(
+    SpaDES.core::simInit2(simInitInput)
+  )
+  expect_s4_class(simTestInit, "simList")
+
+  # Run spades
+  simTest <- SpaDEStestMuffleOutput(
+    SpaDES.core::spades(simTestInit)
+  )
+  expect_s4_class(simTest, "simList")
+
+  # Check result
+  expect_equal(subset(simTest$cbmPools, cohortGroupID == 2)$age, c(0, 0, 1))
+  expect_true(all(
+    subset(simTest$NPP, cohortGroupID == 2)$NPP < subset(simTest$NPP, cohortGroupID == 1)$NPP
+  ))
+
+
+  ## Test: regeneration delay set by cohortDT column ----
+
+  # Set project path
+  projectPath <- file.path(spadesTestPaths$temp$projects, "module_regenDelayCol")
+  dir.create(projectPath)
+  withr::local_dir(projectPath)
+
+  # Set up project
+  simInitInputCol <- simInitInput
+  simInitInputCol$params$CBM_core$default_delay_regen <- 0
+  simInitInputCol$cohortDT$delayRegen <- 2
+
+  # Run simInit
+  simTestInitCol <- SpaDEStestMuffleOutput(
+    SpaDES.core::simInit2(simInitInputCol)
+  )
+  expect_s4_class(simTestInitCol, "simList")
+
+  # Run spades
+  simTestCol <- SpaDEStestMuffleOutput(
+    SpaDES.core::spades(simTestInitCol)
+  )
+  expect_s4_class(simTestCol, "simList")
+
+  # Check result
+  expect_equal(simTestCol$cbmPools, simTest$cbmPools)
+  expect_equal(simTestCol$NPP,      simTest$NPP)
+  expect_equal(simTestCol$emissionsProducts, simTest$emissionsProducts)
+
+})
+
+


### PR DESCRIPTION
- Regeneration delay can be set via the `default_delay_regen` and/or the `cohortDT$delayRegen`  column (the parameter will fill NAs in the column if it exists)
- Test added for 2 cohorts: this checks that the delay can be applied both ways, and if so, the ages in the `cbmPools` output table will reflect this, and `NPP` will be lower for the cohort with the longer delay.
- Documentation updated

The main change here is the the `cbm_vars$state` table now holds the `delay` column. This is first added to the table in the `spinup` event and then kept through each `annual` event. It is ignored by Python and only used to implement the delay afterwards.