### PR TITLE
Products are now yearly instead of cumulative

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -731,6 +731,11 @@ annual <- function(sim) {
     emissionsProducts[, .SD, .SDcols = !"row_idx"] *
       (groupAreas$area[match(emissionsProducts$row_idx, groupAreas$row_idx)] / 10000))
 
+  # making Products yearly rather than cumulative
+  if (!is.null(sim$emissionsProducts)){
+    emissionsProducts["Products"] <- (emissionsProducts["Products"]) - (sum(sim$emissionsProducts[, "Products"]))
+  }
+
   sim$emissionsProducts <- rbind(sim$emissionsProducts, c(simYear = time(sim), emissionsProducts))
 
   ##TODO need to track emissions and products. First check that cbm_vars$fluxes


### PR DESCRIPTION
This tiny change allows the products column in the `emissionsProducts` object to represent values for the current year rather than cumulatively for the whole simulation. 