### PR TITLE
.plot parameter replaces .plotInitialTime and .plotInterval

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -52,8 +52,7 @@ defineModule(sim, list(
     defineParameter(
       "skipPrepareCBMvars", "logical", default = FALSE, NA, NA,
       desc = "Whether the inputs for the cbm annual events are prepared by another module.E.g., LandRCBM_split3pools."),
-    defineParameter(".plotInitialTime", "numeric", start(sim), NA, NA, "Simulation time when the first plot event should occur"),
-    defineParameter(".plotInterval",    "numeric", 1L,         NA, NA, "Time interval between plot events"),
+    defineParameter(".plot", "logical", TRUE, NA, NA, "Plot simulation results"),
     defineParameter(".saveInitialTime", "numeric", NA,         NA, NA, "Simulation time when the first save event should occur"),
     defineParameter(".saveInterval",    "numeric", NA,         NA, NA, "Time interval between save events"),
     defineParameter(".useCache", "logical", FALSE, NA, NA, "Use module caching")
@@ -182,21 +181,11 @@ doEvent.CBM_core <- function(sim, eventTime, eventType, debug = FALSE) {
       sim <- scheduleEvent(sim, start(sim), "CBM_core", "annual_preprocessing", eventPriority = 8)
       sim <- scheduleEvent(sim, start(sim), "CBM_core", "annual_carbonDynamics", eventPriority = 8.5)
 
-      # need this to be after the saving of outputs -- so very low priority
-      ##TODO this is not happening because P(sim)$.plotInterval is NULL
-      # sim <- scheduleEvent(sim, min(end(sim), start(sim) + P(sim)$.plotInterval),
-      #                      "CBM_core", "accumulateResults", eventPriority = 11)
-      ##So, I am making this one until we figure out how to do both more
-      ##generically
+      # Accumulate results
       sim <- scheduleEvent(sim, end(sim), "CBM_core", "accumulateResults", eventPriority = 11)
 
       # Schedule plotting
-      sim <- scheduleEvent(sim, end(sim), "CBM_core", "plot", eventPriority = 12)
-
-
-      #sim <- scheduleEvent(sim, P(sim)$.saveInitialTime, "CBM_core", "save")
-      #sim <- scheduleEvent(sim, P(sim)$.plotInitialTime, "CBM_core", "plot", eventPriority = 12 )
-      # sim <- scheduleEvent(sim, end(sim), "CBM_core", "savePools", .last())
+      if (P(sim)$.plot) sim <- scheduleEvent(sim, end(sim), "CBM_core", "plot", eventPriority = 12)
     },
 
     spinup = {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -5,8 +5,10 @@ if (!testthat::is_testing()){
 }
 
 # 2025-05: Install latest quickPlot from Github required by LandR
+# 2025-07-14: Installing a specific hash of quickPlot
 ## Otherwise SpaDES.core will install and load an older version from CRAN first
-Require::Install("PredictiveEcology/quickPlot@development (>= 1.0.2.9001)")
+# Require::Install("PredictiveEcology/quickPlot@development (>= 1.0.2.9001)")
+Require::Install("PredictiveEcology/quickPlot@5735b68bccdf79a3b032c141d1059950ad9d4334")
 
 # Source work in progress SpaDES module testing functions
 suppressPackageStartupMessages(library(SpaDES.core))

--- a/tests/testthat/test-1-module_1-SK-small_1998-2000.R
+++ b/tests/testthat/test-1-module_1-SK-small_1998-2000.R
@@ -28,6 +28,7 @@ test_that("Module: SK-small 1998-2000", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(projectPath, "outputs")
       ),
+      params = list(CBM_core = list(.plot = FALSE)),
 
       outputs = as.data.frame(expand.grid(
         objectName = c("cbmPools", "NPP"),

--- a/tests/testthat/test-1-module_2-SK_1985-2011.R
+++ b/tests/testthat/test-1-module_2-SK_1985-2011.R
@@ -28,6 +28,7 @@ test_that("Module: SK 1985-2011", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(projectPath, "outputs")
       ),
+      params = list(CBM_core = list(.plot = FALSE)),
 
       outputs = as.data.frame(expand.grid(
         objectName = c("cbmPools", "NPP"),

--- a/tests/testthat/test-1-module_3-regenDelay.R
+++ b/tests/testthat/test-1-module_3-regenDelay.R
@@ -28,6 +28,7 @@ test_that("Module: with regeneration delay", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(projectPath, "outputs")
       ),
+      params = list(CBM_core = list(.plot = FALSE)),
 
       outputs = as.data.frame(expand.grid(
         objectName = c("cbmPools", "NPP"),

--- a/tests/testthat/test-2-integration_SK-small_1998-2000.R
+++ b/tests/testthat/test-2-integration_SK-small_1998-2000.R
@@ -38,6 +38,7 @@ test_that("Multi module: SK-small 1998-2000", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(projectPath, "outputs")
       ),
+      params = list(CBM_core = list(.plot = FALSE)),
 
       require = c("terra", "reproducible"),
 

--- a/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
+++ b/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
@@ -35,7 +35,6 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(projectPath, "outputs")
       ),
-      params = list(CBM_core = list(.plot = FALSE)),
 
       require = c("terra", "reproducible"),
 
@@ -79,6 +78,7 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
           sppEquivCol = 'LandR'
         ),
         CBM_core = list(
+          .plot = FALSE,
           skipCohortGroupHandling = TRUE,
           skipPrepareCBMvars = TRUE
         ))
@@ -116,10 +116,9 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
         "spinup"            = times$start,
         setNames(
           rep(times$start:times$end, each = 2),
-          rep(c("annual_preprocessing", "annual_carbonDynamics"), length(times$star:times$end))
+          rep(c("annual_preprocessing", "annual_carbonDynamics"), length(times$start:times$end))
         ),
-        "accumulateResults" = times$end,
-        "plot"              = times$end
+        "accumulateResults" = times$end
       )),
     expect_equal(
       completed(simTest)[moduleName == moduleTest, .(eventTime, eventType)],

--- a/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
+++ b/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
@@ -35,6 +35,7 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(projectPath, "outputs")
       ),
+      params = list(CBM_core = list(.plot = FALSE)),
 
       require = c("terra", "reproducible"),
 


### PR DESCRIPTION
@camillegiuliano what do you think about changing the plotting parameter options to this, even if temporarily? it seems to me that at the moment, plotting in CBM_core is a yes or no option rather than something that can be scheduled yearly.

My motivation for reviewing this is to have an option to turn plotting off for our tests since it consumes resources to create them, but the tests currently only check that the output tables are valid. In the future it might be useful to have tests that check specifically that the plots work, but it likely would be a better priority to improve our tests for the plotting functions in `CBMutils` first.