### PR TITLE
cohortDT 'ages' column renamed 'age'

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -75,7 +75,7 @@ defineModule(sim, list(
         cohortID    = "Cohort ID",
         pixelIndex  = "Stand ID",
         gcids       = "Growth curve ID",
-        ages        = "Cohort age at simulation start",
+        age         = "Cohort age at simulation start",
         ageSpinup   = "Optional. Alternative cohort age at the simulation start year to use in the spinup",
         delaySpinup = "Optional. Spinup delay. Defaults to the 'default_delay_spinup' parameter",
         delayRegen  = "Optional. Regeneration delay post disturbance in years. Defaults to the 'default_delay_regen' parameter"
@@ -330,7 +330,7 @@ spinup <- function(sim) {
   cohortDT <- sim$cohortDT
   if ("ageSpinup" %in% names(sim$cohortDT)){
     cohortDT <- data.table::copy(cohortDT)
-    data.table::setnames(cohortDT, c("ages", "ageSpinup"), c("agesReal", "ages"))
+    data.table::setnames(cohortDT, c("age", "ageSpinup"), c("agesReal", "age"))
   }
 
   ## Use an area of 1ha for each pixel
@@ -665,7 +665,7 @@ annual_carbonDynamics <- function(sim) {
   ## ASSEMBLE OUTPUTS -----
 
   # Set new cohort group ages
-  sim$cohortGroups$ages <- sim$cbm_vars$state$age[
+  sim$cohortGroups$age <- sim$cbm_vars$state$age[
     match(sim$cohortGroups$cohortGroupID, sim$cbm_vars$state$row_idx)
   ]
 

--- a/R/spinup.R
+++ b/R/spinup.R
@@ -104,18 +104,12 @@ cbmExnSpinupCohorts <- function(
     standDT  = c("area", "historical_disturbance_type", "last_pass_disturbance_type")
   )
 
-  ## Special case: rename "ages" column
-  if ("ages" %in% names(cohortDT) & !"age" %in% names(cohortDT)){
-    cohortDT <- data.table::copy(cohortDT)[, age := ages][, ages := NULL]
-    cpCH <- FALSE
-  }else cpCH <- TRUE
-
   # Read input tables
   standDT  <- readDataTable(
     standDT,  "standDT", copy = TRUE,
     colRequired = reqCols$standDT,  colKeep = optCols$standDT)
   cohortDT <- readDataTable(
-    cohortDT, "cohortDT", copy = cpCH,
+    cohortDT, "cohortDT", copy = TRUE,
     colRequired = reqCols$cohortDT, colKeep = setdiff(names(cohortDT), names(standDT)))
   gcMetaDT <- readDataTable(
     gcMetaDT, "gcMetaDT", copy = TRUE,

--- a/tests/testthat/test-1-module_2-SK_1985-2011.R
+++ b/tests/testthat/test-1-module_2-SK_1985-2011.R
@@ -36,7 +36,7 @@ test_that("Module: SK 1985-2011", {
       )),
 
       standDT           = data.table::fread(file.path(spadesTestPaths$testdata, "SK/input", "standDT.csv"))[, area := 900],
-      cohortDT          = data.table::fread(file.path(spadesTestPaths$testdata, "SK/input", "cohortDT.csv"))[, ageSpinup := sapply(ages, min, 3)],
+      cohortDT          = data.table::fread(file.path(spadesTestPaths$testdata, "SK/input", "cohortDT.csv"))[, ageSpinup := sapply(age, min, 3)],
       disturbanceEvents = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceEvents.csv") |> data.table::fread(),
       disturbanceMeta   = file.path(spadesTestPaths$testdata, "SK/input", "disturbanceMeta.csv")   |> data.table::fread(),
       gcMeta            = file.path(spadesTestPaths$testdata, "SK/input", "gcMeta.csv")            |> data.table::fread(),

--- a/tests/testthat/test-1-module_3-regenDelay.R
+++ b/tests/testthat/test-1-module_3-regenDelay.R
@@ -44,7 +44,7 @@ test_that("Module: with regeneration delay", {
         cohortID   = c(1, 2),
         pixelIndex = c(1, 2),
         gcids      = 1,
-        ages       = 10,
+        age        = 10,
         delayRegen = c(0, 2)
       ),
       disturbanceEvents = data.table::data.table(

--- a/tests/testthat/testdata/SK-small/input/cohortDT.csv
+++ b/tests/testthat/testdata/SK-small/input/cohortDT.csv
@@ -1,4 +1,4 @@
-cohortID,pixelIndex,gcids,ages
+cohortID,pixelIndex,gcids,age
 20,20,52,13
 21,21,52,13
 22,22,52,13


### PR DESCRIPTION
@cboisvenue as discussed: the cohortDT 'ages' column is made singular (one age per cohort) by dropping the 's'. @DominiqueCaron I imagine this requires an update on your end!