### PR TITLE
spinup memory usage improvements

### DIFF
--- a/R/spinup.R
+++ b/R/spinup.R
@@ -2,25 +2,89 @@
 #' Spinup
 #'
 #' Spinup cohort data with libcbmr.
-cbmExnSpinup <- function(cohortDT, spinupSQL, growthIncr, gcIndex = "gcIndex"){
+cbmExnSpinupCBM <- function(
+    cohortDT, standDT, gcMetaDT,
+    colname_gc    = "gcids",
+    colname_age   = "age",
+    colname_delay = "delay",
+    ...){
+
+  # On exit: restore cohortDT table
+  cohortInput <- list(key = data.table::key(cohortDT), cols = names(cohortDT))
+  on.exit({
+    cohortDT <- cohortDT[, .SD, .SDcols = cohortInput$cols]
+    data.table::setkeyv(cohortDT, cohortInput$key)
+  })
+
+  # Set required columns
+  reqCols <- list(
+    cohortDT = list(
+      req = c("cohortID", "pixelIndex", colname_gc, colname_age),
+      opt = names(cohortDT)
+    ),
+    standDT = list(
+      req = c("pixelIndex", "spatial_unit_id"),
+      opt = c("historical_disturbance_type", "last_pass_disturbance_type")
+    ),
+    gcMetaDT = list(
+      req = c(colname_gc, "species_id", "sw_hw"),
+      opt = c()
+    )
+  )
+
+  # Read input tables
+  cohortDT <- readDataTable(cohortDT, "cohortDT", colRequired = reqCols$cohortDT$req, colKeep = reqCols$cohortDT$opt)
+  standDT  <- readDataTable(standDT,  "standDT",  colRequired = reqCols$standDT$req,  colKeep = reqCols$standDT$opt)
+  gcMetaDT <- readDataTable(gcMetaDT, "gcMetaDT", colRequired = reqCols$gcMetaDT$req, colKeep = reqCols$gcMetaDT$opt)
+
+  # Join all cohort data
+  cohortDT <- cohortDT |>
+    merge(standDT,  by = "pixelIndex", all.x = TRUE) |>
+    merge(gcMetaDT, by = colname_gc,   all.x = TRUE)
+  data.table::setkey(cohortDT, cohortID)
+
+  # Set age column
+  if (colname_age != "age"){
+    data.table::setnames(cohortDT, c("age", colname_age), c("age_in", "age"), skip_absent = TRUE)
+    on.exit(
+      data.table::setnames(cohortDT, c("age_in", "age"), c("age", colname_age), skip_absent = TRUE),
+      add = TRUE, after = FALSE)
+  }
+
+  # Set delay column
+  if (colname_delay != "delay"){
+    data.table::setnames(cohortDT, c("delay", colname_delay), c("delay_in", "delay"), skip_absent = TRUE)
+    on.exit(
+      data.table::setnames(cohortDT, c("delay_in", "delay"), c("delay", colname_delay), skip_absent = TRUE),
+      add = TRUE, after = FALSE)
+  }
+
+  # Spinup
+  cbmExnSpinup(cohortDT = cohortDT, colname_gc = colname_gc, ...)
+}
+
+
+#' Spinup
+#'
+#' Spinup cohort data with libcbmr.
+cbmExnSpinup <- function(cohortDT, growthIncr, spinupSQL, colname_gc = "gcids",
+                         default_delay = 0L,
+                         default_historical_disturbance_type = 1L,
+                         default_last_pass_disturbance_type  = 1L){
 
   ## Prepare input for spinup ----
 
   # Set required columns
   reqCols <- list(
-    cohortDT   = c("cohortID", "area", "spatial_unit_id", "species", "sw_hw", "age", gcIndex,
-                   "delay", "historical_disturbance_type", "last_pass_disturbance_type"),
-    spinupSQL  = c("id", "return_interval", "min_rotations", "max_rotations", "mean_annual_temperature"),
-    growthIncr = c(gcIndex, "age", "merch_inc", "foliage_inc", "other_inc")
+    cohortDT   = c("cohortID", "spatial_unit_id", colname_gc, "species_id", "sw_hw", "age"),
+    growthIncr = c(colname_gc, "age", "merch_inc", "foliage_inc", "other_inc"),
+    spinupSQL  = c("id", "return_interval", "min_rotations", "max_rotations", "mean_annual_temperature")
   )
 
   # Read input tables
   cohortDT   <- readDataTable(cohortDT,   "cohortDT",   colRequired = reqCols$cohortDT, colKeep = names(cohortDT))
-  spinupSQL  <- readDataTable(spinupSQL,  "spinupSQL",  colRequired = reqCols$spinupSQL)
   growthIncr <- readDataTable(growthIncr, "growthIncr", colRequired = reqCols$growthIncr)
-
-  # Set sw_hw to be integer
-  if (is.character(cohortDT$sw_hw)) cohortDT$sw_hw <- as.integer(cohortDT$sw_hw == "sw")
+  spinupSQL  <- readDataTable(spinupSQL,  "spinupSQL",  colRequired = reqCols$spinupSQL)
 
   # Create cohort groups: groups of cohorts with the same attributes
   ## Allow all cohortDT attributes to be considered in unique groupings
@@ -31,21 +95,37 @@ cbmExnSpinup <- function(cohortDT, spinupSQL, growthIncr, gcIndex = "gcIndex"){
   # Isolate unique groups and join with spatial unit data
   cohortGroups <- unique(cohortDT[, .SD, .SDcols = c("cohortGroupID", groupCols)])
   cohortGroups <- merge(cohortGroups, spinupSQL, by.x = "spatial_unit_id", by.y = "id", all.x = TRUE)
-  setkeyv(cohortGroups, "cohortGroupID")
+  setkey(cohortGroups, cohortGroupID)
 
-  ## Ensure gcIndex columns have matching data types
-  isFactGC <- sapply(growthIncr[,   gcIndex, with = FALSE], is.factor)
-  isFactCH <- sapply(cohortGroups[, gcIndex, with = FALSE], is.factor)
-  for (gcIndexCol in names(isFactGC)[isFactGC & !isFactCH]){
-    cohortGroups[[gcIndexCol]] <- factor(cohortGroups[[gcIndexCol]], levels(growthIncr[[gcIndexCol]]))
+  # Prepare sw_hw column for Python
+  data.table::setnames(cohortGroups, "species_id", "species")
+  if (is.character(cohortGroups$sw_hw)) cohortGroups$sw_hw <- as.integer(cohortGroups$sw_hw == "sw")
+
+  # Set defaults
+  if (!"area" %in% names(cohortGroups)) cohortGroups$area <- 1L # 1ha
+
+  if ("delay" %in% names(cohortGroups)){
+    cohortGroups$delay[is.na(delay), delay := default_delay]
+  }else{
+    cohortGroups$delay <- default_delay
+  }
+  if ("historical_disturbance_type" %in% names(cohortGroups)){
+    cohortGroups[is.na(historical_disturbance_type), historical_disturbance_type := default_historical_disturbance_type]
+  }else{
+    cohortGroups$historical_disturbance_type <- default_historical_disturbance_type
+  }
+  if ("last_pass_disturbance_type" %in% names(cohortGroups)){
+    cohortGroups[is.na(last_pass_disturbance_type), last_pass_disturbance_type := default_last_pass_disturbance_type]
+  }else{
+    cohortGroups$last_pass_disturbance_type <- default_last_pass_disturbance_type
   }
 
   # Join growth increments with cohort group IDs
   ## Drop growth increments age <= 0
   growthIncrGroups <- merge(
-    cohortGroups[, .SD, .SDcols = c("cohortGroupID", gcIndex)],
+    cohortGroups[, .SD, .SDcols = c("cohortGroupID", colname_gc)],
     subset(growthIncr, age > 0),
-    by = gcIndex, allow.cartesian = TRUE)
+    by = colname_gc, allow.cartesian = TRUE)
 
   growthIncrGroups <- data.table::data.table(
     row_idx = growthIncrGroups$cohortGroupID,
@@ -76,117 +156,11 @@ cbmExnSpinup <- function(cohortDT, spinupSQL, growthIncr, gcIndex = "gcIndex"){
 
   # Return input and results
   list(
-    key        = cohortDT[, .(cohortID, cohortGroupID)],
+    key        = data.table::setkey(cohortDT[, .(cohortID, cohortGroupID)], cohortID),
     increments = growthIncrGroups,
     output     = cbm_vars
   )
 }
-
-
-#' Spinup cohorts
-#'
-#' Prepare cohort, stand, and growth curve data into a table ready for spinup.
-cbmExnSpinupCohorts <- function(
-    cohortDT, standDT, gcMetaDT,
-    gcIndex       = "gcIndex",
-    default_area  = 1,
-    default_delay = 0L,
-    default_historical_disturbance_type = 1L,
-    default_last_pass_disturbance_type  = 1L){
-
-  # Set required columns
-  reqCols <- list(
-    standDT  = c("pixelIndex", "spatial_unit_id"),
-    cohortDT = c("cohortID", "pixelIndex", "age", gcIndex),
-    gcMetaDT = c(gcIndex, "species_id", "sw_hw")
-  )
-  optCols <- list(
-    standDT  = c("area", "historical_disturbance_type", "last_pass_disturbance_type")
-  )
-
-  # Read input tables
-  standDT  <- readDataTable(
-    standDT,  "standDT", copy = TRUE,
-    colRequired = reqCols$standDT,  colKeep = optCols$standDT)
-  cohortDT <- readDataTable(
-    cohortDT, "cohortDT", copy = TRUE,
-    colRequired = reqCols$cohortDT, colKeep = setdiff(names(cohortDT), names(standDT)))
-  gcMetaDT <- readDataTable(
-    gcMetaDT, "gcMetaDT", copy = TRUE,
-    colRequired = reqCols$gcMetaDT) |> unique()
-
-  # Check table column matches
-  if (!all(cohortDT$pixelIndex %in% standDT$pixelIndex)) stop("cohortDT has 'pixelIndex' not present in standDT")
-
-  # Remove cohorts that are missing key attributes
-  cohortDT_isNA <- is.na(cohortDT[, .SD, .SDcols = reqCols$cohortDT])
-  if (any(cohortDT_isNA)){
-
-    rmRow <- apply(cohortDT_isNA, 1, any)
-    rmCol <- apply(cohortDT_isNA, 2, any)
-
-    if (all(rmRow)) stop(
-      "All cohort(s) invalid due to NAs in one or more column(s): ",
-      paste(shQuote(names(rmCol)[rmCol]), collapse = ", "))
-
-    warning(
-      sum(rmRow), " / ", nrow(cohortDT),
-      " cohort(s) removed due to NAs in one or more column(s): ",
-      paste(shQuote(names(rmCol)[rmCol]), collapse = ", "))
-
-    cohortDT <- cohortDT[!rmRow,]
-
-    rm(rmRow)
-    rm(rmCol)
-  }
-  rm(cohortDT_isNA)
-
-  # Set default values
-  if (!"area" %in% names(standDT)){
-    standDT$area <- default_area
-  }
-
-  if ("delaySpinup" %in% names(cohortDT)) data.table::setnames(cohortDT, "delaySpinup", "delay")
-  if (!"delay" %in% names(cohortDT)){
-    cohortDT$delay <- default_delay
-  }else{
-    cohortDT[is.na(delay), delay := default_delay]
-  }
-
-  if (!"historical_disturbance_type" %in% names(cohortDT)){
-    cohortDT$historical_disturbance_type <- default_historical_disturbance_type
-  }else{
-    cohortDT[is.na(historical_disturbance_type), historical_disturbance_type := default_historical_disturbance_type]
-  }
-
-  if (!"last_pass_disturbance_type" %in% names(cohortDT)){
-    cohortDT$last_pass_disturbance_type <- default_last_pass_disturbance_type
-  }else{
-    cohortDT[is.na(last_pass_disturbance_type), last_pass_disturbance_type := default_last_pass_disturbance_type]
-  }
-
-  ## Ensure gcIndex columns have matching data types
-  isFactGC <- sapply(gcMetaDT[, gcIndex, with = FALSE], is.factor)
-  isFactCH <- sapply(cohortDT[, gcIndex, with = FALSE], is.factor)
-  for (gcIndexCol in names(isFactGC)[isFactGC & !isFactCH]){
-    cohortDT[[gcIndexCol]] <- factor(cohortDT[[gcIndexCol]], levels(gcMetaDT[[gcIndexCol]]))
-  }
-
-  # Join all cohort data
-  cohortFull <- cohortDT |>
-    merge(standDT,  by = "pixelIndex", all.x = TRUE) |>
-    merge(gcMetaDT, by = gcIndex,      all.x = TRUE)
-  cohortFull <- cohortFull[, .SD, .SDcols = unique(c(names(cohortDT), names(standDT), names(gcMetaDT)))]
-  data.table::setkey(cohortFull, cohortID)
-
-  # Rename columns
-  data.table::setnames(cohortFull, "species_id", "species")
-
-  # Return
-  return(cohortFull)
-
-}
-
 
 # Helper function: read as data.table and check for required columns
 readDataTable <- function(table = NULL, tableName = NULL, copy = FALSE, colRequired = NULL, colKeep = NULL){


### PR DESCRIPTION
The `spinup` event has been made more efficient by replacing any steps that copy the input tables. In a run of the SK managed forests, this reduced the memory usage of the event from ~(+85 GB, -68 GB) to ~(+19 GB, -6.4 GB), and the speed from ~53s to ~8s.

attn @DominiqueCaron: I know this was a noted RAM bottleneck for you.

Will merge when tests pass but can be reviewed again at a later date.