### PR TITLE
LandR integration test branch update

### DIFF
--- a/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
+++ b/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
@@ -21,8 +21,8 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
     SpaDES.project::setupProject(
 
       modules = c(
-        paste0("PredictiveEcology/Biomass_core@",    Sys.getenv("BRANCH_NAME")),
-        paste0("DominiqueCaron/LandRCBM_split3pools@run-with-CBM"),
+        paste0("PredictiveEcology/Biomass_core@", Sys.getenv("BRANCH_NAME")),
+        "PredictiveEcology/LandRCBM_split3pools@main",
         "CBM_core"
       ),
 


### PR DESCRIPTION
@DominiqueCaron I noticed that the `DominiqueCaron/LandRCBM_split3pools@run-with-CBM` branch is no more. I also see there's no `PredictiveEcology/LandRCBM_split3pools@development` branch. Would this be the correct fix to the integration test branch list?