### PR TITLE
spadesCBMdb replaces NPP and cbmPools

### DIFF
--- a/tests/testthat/test-1-module_3-regenDelay.R
+++ b/tests/testthat/test-1-module_3-regenDelay.R
@@ -25,11 +25,6 @@ test_that("Module: with regeneration delay", {
       ),
       params = list(CBM_core = list(.plot = FALSE)),
 
-      outputs = as.data.frame(expand.grid(
-        objectName = c("cbmPools", "NPP"),
-        saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))
-      )),
-
       standDT = data.table::data.table(
         pixelIndex      = c(1, 2),
         spatial_unit_id = 28,

--- a/tests/testthat/test-2-integration_SK-small_1998-2000.R
+++ b/tests/testthat/test-2-integration_SK-small_1998-2000.R
@@ -30,7 +30,7 @@ test_that("Multi module: SK-small 1998-2000", {
         cachePath   = spadesTestPaths$cachePath,
         outputPath  = file.path(spadesTestPaths$temp$outputs, projectName)
       ),
-      params = list(CBM_core = list(.plot = FALSE)),
+      params = list(CBM_core = list(.plot = TRUE)),
 
       require = "terra",
 
@@ -39,12 +39,7 @@ test_that("Multi module: SK-small 1998-2000", {
         res  = 30,
         vals = 0L,
         crs  = "EPSG:3979"
-      ),
-
-      outputs = as.data.frame(expand.grid(
-        objectName = c("cbmPools", "NPP"),
-        saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))
-      ))
+      )
     )
   )
 
@@ -66,13 +61,6 @@ test_that("Multi module: SK-small 1998-2000", {
   ## Check outputs ----
 
   expect_true(!is.null(simTest$emissionsProducts))
-
-  # # spinupResult ## TEMPORARY: Not currently being saved.
-  # expect_true(!is.null(simTest$spinupResult))
-
-  expect_true(!is.null(simTest$cbmPools))
-
-  expect_true(!is.null(simTest$NPP))
 
 })
 

--- a/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
+++ b/tests/testthat/test-3-integration_LandRCBM_RIA-small_2000-2002.R
@@ -58,12 +58,6 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
         sppEquiv <- sppEquiv[KNN != "" & LANDIS_traits != ""]
       },
 
-
-      outputs = as.data.frame(expand.grid(
-        objectName = c("cbmPools", "NPP"),
-        saveTime   = sort(c(times$start, times$start + c(1:(times$end - times$start))))
-      )),
-
       # Parameters
       params = list(
         .globals = list(
@@ -110,8 +104,7 @@ test_that("Multi module: RIA-small with LandR 2000-2002", {
         setNames(
           rep(times$start:times$end, each = 2),
           rep(c("annual_preprocessing", "annual_carbonDynamics"), length(times$start:times$end))
-        ),
-        "accumulateResults" = times$end
+        )
       )),
     expect_equal(
       completed(simTest)[moduleName == moduleTest, .(eventTime, eventType)],


### PR DESCRIPTION
An update to https://github.com/PredictiveEcology/CBM_core/pull/75 that improves how CBM_core's yearly data is written & read. This was made easier by https://github.com/PredictiveEcology/CBM_core/pull/79 which reduces the number of objects used by the module.

## Description

This update pairs with https://github.com/PredictiveEcology/CBMutils/issues/61 to introduce the SpaDES CBM outputs database to the **CBM_core** module. This PR has been marked as a draft until that PR is merged.

The `NPP` and `cbmPools` output objects are replaced by an output object called `spadesCBMdb` which is a path to a directory containing yearly data dumps of the `cbm_vars` tables to `.qs` files. The `accumulateResults` event no longer needs to occur. Instead, `CBMutils` contains functions that reads and summarizes the saved data, caches it, then passes the summaries to our plotting functions.

This solves the issue we have with our simulations requiring that the user provides the correct `outputs` table object in order to produce the listed module outputs that they require for plotting. This ensures that plotting will always be functional.

Having a special cache sub-directory in `spadesCBMdb` ensures that the main simulation cache doesn't return results from a previous run of the simulation sharing the same `cachePath`. The path to `spadesCBMdb` is always the same for simulations using a certain `outputPath`. To ensure the results are always current, each fresh run of the simulation will delete the directory to ensure the results (and the results cache) is fully overwritten.

### New parameters

- `.saveInitial`: Defaults to `start(sim)`.
- `.saveInterval`: Defaults to 1.
- `.saveAll`: default FALSE. Each year, the `cbm_vars$key`, `cbm_var$flux`, and `cbm_vars$pools` tables are saved to file. If `.saveAll = TRUE`, the `cbm_vars$parameters` and `cbm_vars$state` tables are also saved.
- `.saveSpinup`: default FALSE. Save the tables after the spinup. I have kept a test that sets this to TRUE and checks that the result is as we expect.

Plotting will only include years that had save events (as set with `.saveInitial` and `.saveInterval`).

`.saveAll` default data saving choices were guided by the plotting functions: `cbm_vars$pool` is required each year by `barPlot` to plot the change in pool proportions over time; `cbm_vars$flux` is required to plot NPP.

### Efficiency gains

Profile results running the SK test area, 30m res 28753x21700 masterRaster, 1985-1990:

With plotting:

| Branch | Format | RAM (MB) | time (s) |
| --- | --- | --- | --- |
| development | `NPP` & `cbmPools` | 383,524 | 705 |
| suz-CBMdb | .qs | 327,714 | 452 |

Without plotting:

| Branch | Format | RAM (MB) | time (s) |
| --- | --- | --- | --- |
| development | `NPP` & `cbmPools` | 367,189 | 574 |
| suz-CBMdb | .qs | 297,820 | 439 |

There are 2 reasons why our current `development` branch lags behind:
1. For runs without plotting: in development, the `NPP` and `cbmPools` objects are created regardless of whether they are being used anywhere. This update allows us to run the simulation, produce results, and leave the heavy lifting of summarizing the data for later when it's time to generate results.
2. Having the large tables `NPP` and `cbmPools` in our simList forces the module to cache them after every `annual_carbonDynamics` and `accumulateResults` event where they are modified (I believe): so instead of this data being saved once to file, they're actually being saved multiple times. In the `development` run, it was observed that ~2.6GB of data was being saved for every `annual_carbonDynamics` event; this was reduced to  ~1.6GB in the .qs run.

### What's next

Non-urgent: do we want to consider having the module save some useful data summaries to CSV for easy user access? This could happen either by default or we could add parameters that provide options to do this. 

