### PR TITLE
spinup eventPriority = 5

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -160,7 +160,7 @@ doEvent.CBM_core <- function(sim, eventTime, eventType, debug = FALSE) {
       sim <- Init(sim)
 
       # Schedule spinup
-      sim <- scheduleEvent(sim, start(sim), "CBM_core", "spinup")
+      sim <- scheduleEvent(sim, start(sim), "CBM_core", "spinup", eventPriority = 5)
 
       # Schedule annual event
       sim <- scheduleEvent(sim, start(sim), "CBM_core", "annual_preprocessing", eventPriority = 8)


### PR DESCRIPTION
What do we think about pushing the spinup event priority to something higher? Here I suggest 5.

It would be nice to break **CBM_dataPrep** into multiple events, however, it's hard to squeeze everything in before the spinup as it is. This would leave space to do the same in vol2biomass as well.