### PR TITLE
GHA test only release R versions

### DIFF
--- a/.github/workflows/testthat-integration.yaml
+++ b/.github/workflows/testthat-integration.yaml
@@ -19,9 +19,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'devel'}
           - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'devel'}
           #- {os: macOS-latest,   r: 'release'}
 
     env:

--- a/.github/workflows/testthat-module.yaml
+++ b/.github/workflows/testthat-module.yaml
@@ -22,9 +22,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: 'devel'}
           - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'devel'}
           #- {os: macOS-latest,   r: 'release'}
 
     env:


### PR DESCRIPTION
In light of our GHA failing on linux with the development version of R for reasons not relevant to us: I think it probably makes the most sense to have our modules test only on the current release R versions for Windows, Linux, and Mac. This PR removes the Windows and Linux development R version runners.

I've revisited our issue with our GHA on the mac OS runner but split it into another issue: https://github.com/PredictiveEcology/CBM_core/issues/85

We will keep the R development runners on the CBMutils R package so we'll still have something to keep us on our toes. For our modules I think it's mostly over-testing that seems to act as an early finder of bugs installing SpaDES. If this works and makes sense I'll follow this with the same update for all of our modules. 