### PR TITLE
Python set up updates

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -307,7 +307,11 @@ Init <- function(sim){
     python = CBMutils::ReticulateFindPython(
       version        = ">=3.9,<=3.12.7",
       versionInstall = "3.11:latest",
-      pyenvOnly      = TRUE),
+      pyenvOnly      = TRUE))
+
+  reticulate::virtualenv_install(
+    "r-spadesCBM",
+    pip_options = "--upgrade",
     packages = c(
       "numpy<2",
       "pandas>=1.1.5",


### PR DESCRIPTION
2 updates:
- Default Python install version bumped from 3.10:latest to 3.11:latest (following recommendation by reticulate)
- Python packages are now updated to the latest version (unless a maximum version is set)

I realized I was working with libcbm 2.6.6 but the latest is 2.9.1! This will keep us up to date with the latest releases.