### PR TITLE
mean_annual_temperature set in parameters for every annual step

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -552,6 +552,14 @@ annual_carbonDynamics <- function(sim) {
 
   ## RUN PYTHON -----
 
+  # Set mean_annual_temperature
+  if (!"mean_annual_temperature" %in% names(sim$cbm_vars$parameters)){
+
+    sim$cbm_vars$parameters[, mean_annual_temperature := sim$spinupSQL$mean_annual_temperature[match(
+      sim$cbm_vars$state$spatial_unit_id, sim$spinupSQL$id
+    )]]
+  }
+
   # Temporarily remove row_idx column
   row_idx <- sim$cbm_vars$parameters$row_idx
   for (i in 2:length(sim$cbm_vars)) sim$cbm_vars[[i]][, row_idx := NULL]


### PR DESCRIPTION
@DominiqueCaron I'm in the process of reviewing how we manage and set our CBM parameters and noted this as a place that could be improved. I'd like to centralize where CBM parameters are set or altered to get us set up for when we want to start tweaking their values. In this process, the `spinupSQL` object may or may not survive, but makes it so that **LandRCBM_split3pools** will no longer need to use it.

Currently, we have  `mean_annual_temperature` being set initially using `spinupSQL` in the parameters for the spinup, but then if the parameter `skipPrepareCBMvars = FALSE` it becomes up to other modules (such as **LandRCBM_split3pools**) to set it again from the `spinupSQL` object. This will allow you to pass a table of updated increments to the annual step without re-providing the `mean_annual_temperature`.