### PR TITLE
pandas Python package version restricted to >=2.3.3

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -311,7 +311,7 @@ Init <- function(sim){
     pip_options = c("--upgrade", "-q"[identical(Sys.getenv("TESTTHAT"), "true")]),
     packages = c(
       "numpy<2",
-      "pandas>=1.1.5",
+      "pandas>=1.1.5,<=2.3.3",
       "scipy",
       "numexpr>=2.8.7",
       "numba",


### PR DESCRIPTION
The pandas Python package released version 3.0 today, up from 2.3.3: https://github.com/pandas-dev/pandas/releases/tag/v3.0.0

Without restricting the package version to <=2.3.3 now getting an error calling `libcbmr::cbm_exn_spinup`:

```
Error in py_call_impl(callable, call_args$unnamed, call_args$named) : 
  numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
No implementation of function Function(<built-in function setitem>) found for signature:
<...truncated...>tation raised a specific error:
         NumbaTypeError: Cannot modify readonly array of type: readonly array(int32, 1d, C)
  raised from [virtual_env_path]\Lib\site-packages\numba\core\typing\arraydecl.py:228

During: typing of setitem at C:\Users\sumurray\DOCUME~1\VIRTUA~1\R-SPAD~4\Lib\site-packages\libcbm\model\model_definition\spinup_engine.py (112)

File "[virtual_env_path]\Lib\site-packages\libcbm\model\model_definition\spinup_engine.py", line 112:
def _advance_spinup_state(
    <source elided>
        if not enabled[i]:
            out_state[i] = SpinupState.End
            ^

During: Pass nopython_type_inference
Run `reticulate::py_last_error()` for details.
```

I'll have to PR a similar commit to main.