### PR TITLE
`standDT` has the 'admin_name' and 'eco_id' columns instead of 'spatial_unit_id'

### DIFF
--- a/CBM_core.R
+++ b/CBM_core.R
@@ -54,12 +54,13 @@ defineModule(sim, list(
   ),
   inputObjects = bindrows(
     expectsInput(
-      objectName = "standDT", objectClass = "data.table", sourceURL = NA,
+      objectName = "standDT", objectClass = "data.table",
       desc = "Table of stand attributes. Stands can have 1 or more cohorts.",
       columns = c(
-        pixelIndex      = "Stand ID",
-        area            = "Stand area in meters",
-        spatial_unit_id = "CBM-CFS3 spatial unit ID",
+        pixelIndex = "Stand ID",
+        area       = "Stand area in meters",
+        admin_name = "Canada province or territory name",
+        eco_id     = "Canada ecozone ID",
         historical_disturbance_type = "Historic CBM-CFS3 disturbance type ID. Defaults to the 'historical_disturbance_type' parameter",
         last_pass_disturbance_type  = "Last pass CBM-CFS3 disturbance type ID. Defaults to the 'last_pass_disturbance_type' parameter"
       )),

--- a/R/cbmEXN_spinup.R
+++ b/R/cbmEXN_spinup.R
@@ -20,23 +20,28 @@ cbmEXN_spinup <- function(cohortDT, growthMeta, growthIncr,
 
   # Read spatial unit parameters
   cbmDBcon <- RSQLite::dbConnect(RSQLite::dbDriver("SQLite"), libcbmr::get_cbm_defaults_path())
-  spuMeta <- merge(
-    RSQLite::dbReadTable(cbmDBcon, "spatial_unit"),
-    RSQLite::dbReadTable(cbmDBcon, "spinup_parameter"),
-    by.x = "spinup_parameter_id", by.y = "id", all.x = TRUE)
+  spuMeta <- data.table::as.data.table(RSQLite::dbReadTable(cbmDBcon, "spatial_unit")) |>
+    merge(data.table::as.data.table(RSQLite::dbReadTable(cbmDBcon, "spinup_parameter")),
+          by.x = "spinup_parameter_id", by.y = "id") |>
+    merge(data.table::as.data.table(RSQLite::dbReadTable(cbmDBcon, "admin_boundary_tr"))[
+      locale_id == 1, .(admin_boundary_id, admin_name = name)],
+      by = "admin_boundary_id")
+  data.table::setnames(spuMeta, "id", "spatial_unit_id")
   RSQLite::dbDisconnect(cbmDBcon)
 
   # Read input tables
   reqCols <- list(
-    cohortDT   = c("cohortID", "spatial_unit_id", colname_gc, colname_age),
-    spuMeta    = c("id", "return_interval", "min_rotations", "max_rotations", "mean_annual_temperature"),
+    cohortDT   = c("cohortID", colname_gc, colname_age),
     growthMeta = c(colname_gc, colname_species, "sw_hw"),
     growthIncr = c(colname_gc, "age", "merch_inc", "foliage_inc", "other_inc")
   )
   cohortDT   <- readDataTable(cohortDT,   "cohortDT",   colRequired = reqCols$cohortDT)
-  spuMeta    <- readDataTable(spuMeta,    "spuMeta",    colRequired = reqCols$spuMeta)
   growthMeta <- readDataTable(growthMeta, "growthMeta", colRequired = reqCols$growthMeta)
   growthIncr <- readDataTable(growthIncr, "growthIncr", colRequired = reqCols$growthIncr)
+
+  if (!"spatial_unit_id" %in% names(cohortDT) &
+      !all(c("admin_name", "eco_id") %in% names(cohortDT))) stop(
+        "cohortDT must have either 'spatial_unit_id' or 'admin_name' and 'eco_id' columns")
 
   # Create cohort groups: groups of cohorts with the same attributes
   ## Allow all cohortDT attributes to be considered in unique groupings
@@ -50,11 +55,17 @@ cbmEXN_spinup <- function(cohortDT, growthMeta, growthIncr,
 
   # Isolate unique groups and join with parameters
   cohortGroups <- unique(cohortDT[, .SD, .SDcols = c("row_idx", groupCols)])
+
+  if ("spatial_unit_id" %in% names(cohortGroups)){
+    spuMetaJoin <- "spatial_unit_id"
+  }else{
+    data.table::setnames(cohortGroups, "eco_id", "eco_boundary_id")
+    spuMetaJoin <- c("admin_name", "eco_boundary_id")
+  }
+
   cohortGroups <- cohortGroups |>
-    data.table::merge.data.table(spuMeta, by.x = "spatial_unit_id", by.y = "id",
-                                 suffixes = c("", ".y"), all.x = TRUE) |>
-    data.table::merge.data.table(growthMeta, by = colname_gc,
-                                 suffixes = c("", ".y"), all.x = TRUE)
+    merge(spuMeta,    by = spuMetaJoin, suffixes = c("", ".y"), all.x = TRUE) |>
+    merge(growthMeta, by = colname_gc,  suffixes = c("", ".y"), all.x = TRUE)
   cohortGroups[, which(grepl("\\.y$", names(cohortGroups))) := NULL]
   data.table::setkey(cohortGroups, row_idx)
 


### PR DESCRIPTION
This is a part of a few module updates to make things more compatible with CBM4. One thing that is notable in CBM4 is that it's going to require the administrative boundary full name (e.g. "Saskatchewan") and the ecozone ID to run instead of just the CBM spatial unit ID. 

### Description

**Updates:**
1. `cbmEXN_spinup` can accept a table with 'admin_name' and 'eco_id` or the 'spatial_unit_id' already preset
2. `standDT` documentation asks the user to provide the 'admin_name' and 'eco_id' columns instead of 'spatial_unit_id'

Since `cbmEXN_spinup` can still accept the 'spatial_unit_id' that we are currently passing from **CBM_dataPrep** this PR will not affect our current simulations.

This is a move towards having the responsibility of getting the spatial unit ID from **CBM_dataPrep** to **CBM_core**. This occurs during a step where the CBM defaults db is already being read to retrieve the spinup parameters, so I think this makes good organizational sense. I think it also logically makes sense to start thinking of the spatial unit ID as an "internal ID" that the user doesn't need to necessarily be aware of or set correctly during data prep.

Following this I will PR:
1. An update to **CBM_vol2biomass** that uses `userGcLocations` instead of `userGcSPU` (https://github.com/PredictiveEcology/CBM_vol2biomass/issues/37): a table with `admin_abbrev` and `eco_id` instead of `spatial_unit_id`. This will allow us to no longer need to set the `spatial_unit_id` in **CBM_dataPrep**.
2. An update to **CBM_dataPrep** that adds the `admin_name` and removes the `spatial_unit_id` from the standDT table.

### Naming conventions

Interested in any feedback here:

I've opted to rename the `ecozone` field to `eco_id`. This is because in the CBM4 world, there is the `eco_boundary_id` (the ecozone ID) and the `eco_boundary` which is the ecozone name. My thinking here is that 'ecozone' is too generic to know which one you are working with.

If we wanted to standardize how we provide the admin & ecozone columns across our modules, I might suggest:

Ecozone columns:
- `eco_id`: Ecozone ID; same as the CBM `eco_boundary_id`
- `eco_name`: Ecozone name; in CBM4 this is the `eco_boundary`

Admin columns:
- `admin_abbrev` **: Admin abbreviation ("SK"); not used by CBM. Used by **CBM_vol2biomass** to retrieve Boudewyn parameters where this is called the `juris_id`.
- `admin_name`: Admin name ("Saskatchewan"); in CBM4 this is the `admin_boundary`

** _Should we rename `admin_abbrev` `admin_id`_? I note that in the CBM defaults DB, there is a numeric `admin_boundary_id` that may be used internally by **CBM_core** but not elsewhere. If we're not worried about potentially getting those confused I would maybe opt for that.